### PR TITLE
Switch to transaction converter runtime api

### DIFF
--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -112,11 +112,11 @@ where
     // )?;
 
 	module.merge(
-        Eth::new(
+        Eth::<_, _, _, fp_rpc::NoTransactionConverter, _, _, _>::new(
             client.clone(),
 			pool.clone(),
             graph,
-            Some(origintrail_parachain_runtime::TransactionConverter),
+            None,
             network.clone(),
             signers,
             overrides.clone(),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -649,30 +649,6 @@ construct_runtime!(
 	}
 );
 
-pub struct TransactionConverter;
-
-impl fp_rpc::ConvertTransaction<UncheckedExtrinsic> for TransactionConverter {
-	fn convert_transaction(&self, transaction: pallet_ethereum::Transaction) -> UncheckedExtrinsic {
-		UncheckedExtrinsic::new_unsigned(
-			pallet_ethereum::Call::<Runtime>::transact { transaction }.into(),
-		)
-	}
-}
-
-impl fp_rpc::ConvertTransaction<opaque::UncheckedExtrinsic> for TransactionConverter {
-	fn convert_transaction(
-		&self,
-		transaction: pallet_ethereum::Transaction,
-	) -> opaque::UncheckedExtrinsic {
-		let extrinsic = UncheckedExtrinsic::new_unsigned(
-			pallet_ethereum::Call::<Runtime>::transact { transaction }.into(),
-		);
-		let encoded = extrinsic.encode();
-		opaque::UncheckedExtrinsic::decode(&mut &encoded[..])
-			.expect("Encoded extrinsic is always valid")
-	}
-}
-
 #[cfg(feature = "runtime-benchmarks")]
 #[macro_use]
 extern crate frame_benchmarking;
@@ -891,6 +867,14 @@ impl_runtime_apis! {
 
 		fn elasticity() -> Option<Permill> {
 			Some(BaseFee::elasticity())
+		}
+	}
+
+	impl fp_rpc::ConvertTransactionRuntimeApi<Block> for Runtime {
+		fn convert_transaction(transaction: EthereumTransaction) -> <Block as BlockT>::Extrinsic {
+			UncheckedExtrinsic::new_unsigned(
+				pallet_ethereum::Call::<Runtime>::transact { transaction }.into(),
+			)
 		}
 	}
 


### PR DESCRIPTION
This reflects the changes from https://github.com/paritytech/frontier/pull/559

I've taken the simpler approach that entirely removes the old hard-coded converter. But if this code is already used in production, you need to restore that converter and provide it on the client side as well.