### PR TITLE
feat: Add nix flake setup with envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+use_flake() {
+  watch_file flake.nix
+  watch_file flake.lock
+  eval "$(nix print-dev-env)"
+}
+use flake

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5235,7 +5235,7 @@ dependencies = [
 
 [[package]]
 name = "origintrail-parachain-runtime"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -5266,6 +5266,8 @@ dependencies = [
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-treasury",
+ "pallet-vesting",
  "pallet-xcm",
  "parachain-info",
  "parity-scale-codec",

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,102 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1661581637,
+        "narHash": "sha256-Z1FtMPFoUUGqedmwpdXycRrQsVPvJk1LByOcd+FhTuc=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "962dafad624929bf713b6e9da38aeb8818da219e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1655042882,
+        "narHash": "sha256-9BX8Fuez5YJlN7cdPO63InoyBy7dm3VlJkkmTt6fS1A=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1661361016,
+        "narHash": "sha256-Bjf6ZDnDc6glTwIIItvwfcaeJ5zWFM6GYfPajSArdUY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b784c5ae63dd288375af1b4d37b8a27dd8061887",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661539193,
+        "narHash": "sha256-LJ+Ry218HavJKZDBpexiASLE4k1k4nhaZv8qb1YvG5Y=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "6bea872edd9523a06213270f68725c9fe33f3919",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,92 @@
+{
+  description = "OriginTrail parachain node";
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    naersk = {
+      url = "github:nix-community/naersk";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    , naersk
+    , fenix
+    }:
+    flake-utils.lib.eachDefaultSystem (system:
+    let
+      lib = nixpkgs.lib;
+      pkgs = nixpkgs.legacyPackages.${system};
+      fenix-pkgs = fenix.packages.${system};
+      rust = with fenix-pkgs; combine [
+        default.toolchain
+        targets.wasm32-unknown-unknown.latest.toolchain
+      ];
+      # Get a naersk with the input rust version
+      naerskWithRust = rust: naersk.lib."${system}".override {
+        rustc = rust;
+        cargo = rust;
+      };
+      env = with pkgs; {
+        LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+        PROTOC = "${protobuf}/bin/protoc";
+        ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+      };
+      # Naersk using the default rust version
+      buildRustProject = pkgs.makeOverridable ({ naersk ? naerskWithRust rust, ... } @ args: with pkgs; naersk.buildPackage ({
+        buildInputs = [
+          clang
+          pkg-config
+        ] ++ lib.optionals stdenv.isDarwin [
+          darwin.apple_sdk.frameworks.Security
+        ];
+        copyLibs = true;
+        copyBins = true;
+        targets = [ ];
+        remapPathPrefix =
+          true; # remove nix store references for a smaller output package
+      } // env // args));
+
+      crateName = "origintrail-parachain";
+      root = ./.;
+      # This is a wrapper around naersk build
+      # Remember to add Cargo.lock to git for naersk to work
+      project = buildRustProject {
+        inherit root;
+        copySources = [ "node" "pallets" "runtime" ];
+      };
+      # Running tests
+      testProject = project.override {
+        doCheck = true;
+      };
+    in
+    {
+      packages = {
+        ${crateName} = project;
+        "${crateName}-test" = testProject;
+      };
+
+      defaultPackage = self.packages.${system}.${crateName};
+
+      # `nix develop`
+      devShell = pkgs.mkShell (env // {
+        inputsFrom = builtins.attrValues self.packages.${system};
+        nativeBuildInputs = [ rust ];
+        buildInputs = [
+          fenix-pkgs.rust-analyzer
+          pkgs.clippy
+          fenix-pkgs.default.rustfmt
+        ];
+      });
+    });
+}


### PR DESCRIPTION
# Description

This adds a nix flake which makes building and deploying much easier. It provides a rust toolchain and loads _all_ necessary dependencies into the environment which can be loaded automatically with `direnv`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

The node builds without any additional installation with `cargo build` inside the `nix develop` environment and with `nix build` for fully content addressed builds.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
