### PR TITLE
Testnet Release 1.2.0 - Sudo removal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "origintrail-parachain-runtime"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -6056,7 +6056,6 @@ dependencies = [
  "pallet-preimage",
  "pallet-scheduler",
  "pallet-session",
- "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,6 +1,6 @@
 use cumulus_primitives_core::ParaId;
 use origintrail_parachain_runtime::{AccountId, AuraId,
-	EVMConfig, EthereumConfig, Signature, SudoConfig, EXISTENTIAL_DEPOSIT};
+	EVMConfig, EthereumConfig, Signature, EXISTENTIAL_DEPOSIT};
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
 use serde::{Deserialize, Serialize};
@@ -181,7 +181,7 @@ pub fn local_testnet_config() -> ChainSpec {
 
 fn testnet_genesis(
 	invulnerables: Vec<(AccountId, AuraId)>,
-	root_key: AccountId,
+	_root_key: AccountId,
 	endowed_accounts: Vec<AccountId>,
 	id: ParaId,
 ) -> origintrail_parachain_runtime::GenesisConfig {
@@ -220,10 +220,10 @@ fn testnet_genesis(
 		polkadot_xcm: origintrail_parachain_runtime::PolkadotXcmConfig {
 			safe_xcm_version: Some(SAFE_XCM_VERSION),
 		},
-		sudo: SudoConfig {
-			// Assign network admin rights.
-			key: Some(root_key),
-		},
+		// sudo: SudoConfig {
+		// 	// Assign network admin rights.
+		// 	key: Some(root_key),
+		// },
 		vesting: Default::default(),
 		treasury: Default::default(),
 		evm: EVMConfig {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "origintrail-parachain-runtime"
-version = "1.1.2"
+version = "1.2.0"
 authors = ["TraceLabs"]
 description = "OriginTrail Parachain Runtime - Cumulus FRAME-based Substrate Runtime"
 license = "GPL-3.0-only"
@@ -39,7 +39,6 @@ pallet-authorship = { git = "https://github.com/paritytech/substrate", default-f
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 pallet-scheduler = { git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "polkadot-v0.9.40" }
 pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.40" }
@@ -136,7 +135,6 @@ std = [
 	"pallet-preimage/std",
 	"pallet-scheduler/std",
 	"pallet-session/std",
-	"pallet-sudo/std",
 	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
@@ -211,7 +209,6 @@ try-runtime = [
 	"pallet-preimage/try-runtime",
 	"pallet-scheduler/try-runtime",
 	"pallet-session/try-runtime",
-	"pallet-sudo/try-runtime",
 	"pallet-utility/try-runtime",
 	"pallet-vesting/try-runtime",
 	"pallet-timestamp/try-runtime",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -250,7 +250,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("origintrail-parachain"),
     impl_name: create_runtime_str!("origintrail-parachain"),
     authoring_version: 1,
-    spec_version: 112,
+    spec_version: 120,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -618,11 +618,6 @@ impl pallet_scheduler::Config for Runtime {
     type WeightInfo = ();
     type Preimages = Preimage;
     type OriginPrivilegeCmp = EqualPrivilegeOnly;
-}
-
-impl pallet_sudo::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type RuntimeCall = RuntimeCall;
 }
 
 parameter_types! {
@@ -1091,9 +1086,6 @@ construct_runtime!(
         Council: pallet_collective::<Instance1> = 62,
         Democracy: pallet_democracy = 63,
         Identity: pallet_identity = 64,
-
-        // Temporary.
-        Sudo: pallet_sudo = 255,
     }
 );
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -250,7 +250,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("origintrail-parachain"),
     impl_name: create_runtime_str!("origintrail-parachain"),
     authoring_version: 1,
-    spec_version: 112,
+    spec_version: 113,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
In this Testnet release, we are removing the Sudo pallet from the OriginTrail Parachain. With this change and the introduction of OriginTrail Parachain Governance in the previous release, the control of the Parachain will be handed over from Sudo to the Governance.