### PR TITLE
Mainnet Runtime update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6242,7 +6242,7 @@ dependencies = [
 
 [[package]]
 name = "neuroweb-runtime"
-version = "146.0.0"
+version = "147.0.0"
 dependencies = [
  "assets-common",
  "cumulus-pallet-aura-ext",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neuroweb-runtime"
-version = "146.0.0"
+version = "147.0.0"
 authors = ["TraceLabs"]
 description = "NeuroWeb Runtime - Cumulus FRAME-based Substrate Runtime"
 license = "GPL-3.0-only"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -152,7 +152,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("origintrail-parachain"),
     impl_name: create_runtime_str!("neuroweb"),
     authoring_version: 1,
-    spec_version: 146,
+    spec_version: 147,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -386,6 +386,30 @@ type Reserves = (
     NativeAsset,
 );
 
+
+parameter_types! {
+    pub NativeAssetFilter: AssetFilter = Wild(AllOf { fun: WildFungible, id: TokenLocation::get().into() });
+    pub AssetHubTrustedTeleporter: (AssetFilter, Location) = (NativeAssetFilter::get(), AssetHubLocation::get());
+
+}
+
+pub type TrustedTeleporters = (xcm_builder::Case<AssetHubTrustedTeleporter>,);
+
+pub struct OnlyTeleportNative;
+impl Contains<(Location, Vec<Asset>)> for OnlyTeleportNative {
+    fn contains(t: &(Location, Vec<Asset>)) -> bool {
+        let native = TokenLocation::get();
+        t.1.iter().all(|asset| {
+            log::trace!(target: "xcm::OnlyTeleportNative", "Asset to be teleported: {:?}", asset);
+            if let Asset { id: asset_id, fun: Fungible(_) } = asset {
+                asset_id.0 == native
+            } else {
+                false
+            }
+        })
+    }
+}
+
 pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
     type RuntimeCall = RuntimeCall;
@@ -394,7 +418,7 @@ impl xcm_executor::Config for XcmConfig {
     type AssetTransactor = AssetTransactors;
     type OriginConverter = XcmOriginToTransactDispatchOrigin;
     type IsReserve = Reserves;
-    type IsTeleporter = (); // Teleporting is disabled.
+    type IsTeleporter = TrustedTeleporters;
     type UniversalLocation = UniversalLocation;
     type Barrier = Barrier;
     type Weigher = WeightInfoBounds<
@@ -452,7 +476,7 @@ impl pallet_xcm::Config for Runtime {
     // ^ Disable dispatchable execute on the XCM pallet.
     // Needs to be `Everything` for local testing.
     type XcmExecutor = XcmExecutor<XcmConfig>;
-    type XcmTeleportFilter = Nothing;
+    type XcmTeleportFilter = OnlyTeleportNative;
     type XcmReserveTransferFilter = Everything;
     type Weigher = WeightInfoBounds<
         crate::weights::xcm::NeurowebXcmWeight<RuntimeCall>,


### PR DESCRIPTION
# Description

- Runtime version bump (spec_version 146 → 147)
- NEURO teleport enabled in XCM configuration
- Updated Cargo.lock with new dependencies
